### PR TITLE
Preserve string value of looks-like-integer parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,19 @@ An option parameter (optional).
 
 Defines whether an option is required. If the field is `true`, a generic error is thrown, otherwise you can set a custom error message by setting to a `string`.
 
+***
+
+### Integer parameter parsing
+
+Capitano will automatically call `parseInt` on parameters that consist of numbers only, like '0123'
+(matched against a regular expression). Sometimes this may not desirable, for example if leading
+zeroes must be preserved. If Capitano calls `parseInt` on a parameter, a copy of the original value
+is preserved under a parameter name with the added '\_raw' suffix. For example, if the original
+value of parameter `foo` was `'0123'`, `params.foo` will contain `123` (number type) and
+`params.foo_raw` will contain `'0123'` (string type).
+
+***
+
 Examples
 --------
 

--- a/build/signature.js
+++ b/build/signature.js
@@ -163,6 +163,7 @@ module.exports = Signature = (function() {
         if (!parameter.isWord() && (word != null)) {
           if (/^\d+$/.test(word)) {
             result[parameterValue] = _.parseInt(word);
+            result[parameterValue + '_raw'] = word;
           } else {
             result[parameterValue] = word;
           }

--- a/lib/signature.coffee
+++ b/lib/signature.coffee
@@ -147,6 +147,7 @@ module.exports = class Signature
 			if not parameter.isWord() and word?
 				if /^\d+$/.test(word)
 					result[parameterValue] = _.parseInt(word)
+					result[parameterValue + '_raw'] = word
 				else
 					result[parameterValue] = word
 

--- a/tests/signature.spec.coffee
+++ b/tests/signature.spec.coffee
@@ -694,10 +694,11 @@ describe 'Signature:', ->
 
 			it 'should parse the numbers automatically', (done) ->
 				signature = new Signature('foo <bar>')
-				signature.compileParameters 'foo 19', (error, result) ->
+				signature.compileParameters 'foo 019', (error, result) ->
 					expect(error).to.not.exist
 					expect(result).to.deep.equal
 						bar: 19
+						bar_raw: '019'
 					done()
 
 			it 'should match with a string that starts with a number', (done) ->


### PR DESCRIPTION
Where Capitano automatically calls `parseInt()` for parameters that look like a decimal integer based on a regex, preserve the parameter's string value as a property named with a `'_raw'` suffix.

This change is specifically aimed at addressing issue: balena-io/balena-cli/issues/1108 _(Balena device not working when device UUID has a 0 as first character)_

It also provides a workaround for some cases of Capitano issue /issues/60 _(Add types to parameters, and enforce them)_

Connects-to: /issues/60
Connects-to: balena-io/balena-cli/issues/1108
Change-type: minor
Signed-off-by: Paulo Castro <paulo@balena.io>